### PR TITLE
[BUGFIX] Set proper php-html-parser version constraint for TYPO3 9.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "guzzlehttp/guzzle": "^6.3||^7.2",
         "league/climate": "^3.6",
         "league/uri": "^6.3",
-        "paquettg/php-html-parser": "^3.1",
+        "paquettg/php-html-parser": "^3.0||^3.1",
         "seostats/seostats": "^2.5",
         "t1gor/robots-txt-parser": "^0.2.4"
     },


### PR DESCRIPTION
paquettg/php-html-parser ^3.1 requires guzzlehttp/guzzle ^7.0, but typo3/cms-core ^9.5.22 requires guzzlehttp/guzzle ^6.3.0. 
paquettg/php-html-parser ^3.0 is now also allowed, so guzzlehttp/guzzle ^6.3.0 is used for typo3/cms-core ^9.5.22.

related to #4 